### PR TITLE
Add multidoc support for record.

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"sync"
 
 	"github.com/eddiezane/hook/pkg/hook"
 
@@ -21,39 +23,75 @@ var recordCommand = &cobra.Command{
 	RunE:    record,
 }
 
+type recorder struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+func newRecorder(path string) (*recorder, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return &recorder{
+		f: f,
+	}, nil
+}
+
+func (r *recorder) close() error {
+	return r.f.Close()
+}
+
+func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// TODO(eddiezane): Handle http error response
+
+	// TODO(eddiezane): Log body? If so need to clone the readcloser
+	log.Printf("method: %s, headers: %v", req.Method, req.Header)
+
+	h, err := hook.NewFromRequest(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s, err := h.Dump()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// TODO(eddiezane): Would this ever happen?
+	if len(s) != 0 {
+		// TODO(eddiezane): Create dirs
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		fw := bufio.NewWriter(r.f)
+		if fi, err := r.f.Stat(); err == nil && fi.Size() > 0 {
+			// If file has data in it already, append doc separator.
+			if _, err := fw.Write([]byte("---\n")); err != nil {
+				log.Fatal(err)
+			}
+		}
+		if _, err := fw.Write(s); err != nil {
+			log.Fatal(err)
+		}
+		fw.Flush()
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
 func record(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("incorrect number of arguments provided. expected %d", 1)
 	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// TODO(eddiezane): Handle http error response
-
-		// TODO(eddiezane): Log body? If so need to clone the readcloser
-		log.Printf("method: %s, headers: %v", r.Method, r.Header)
-
-		h, err := hook.NewFromRequest(r)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		s, err := h.Dump()
-		if err != nil {
-			log.Fatal(err)
-		}
-		// TODO(eddiezane): Would this ever happen?
-		if len(s) != 0 {
-			// TODO(eddiezane): Create dirs
-			if err := ioutil.WriteFile(args[0], s, 0644); err != nil {
-				log.Fatal(err)
-			}
-		}
-
-		w.WriteHeader(http.StatusOK)
-	})
+	r, err := newRecorder(args[0])
+	if err != nil {
+		return err
+	}
+	defer r.close()
 
 	log.Printf("starting server on port %s", port)
-	return http.ListenAndServe(":"+port, nil)
+	return http.ListenAndServe(":"+port, r)
 }
 
 func init() {

--- a/cmd/record_test.go
+++ b/cmd/record_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/eddiezane/hook/pkg/hook"
+	"github.com/kylelemons/godebug/diff"
+)
+
+func testfile(t *testing.T, path string) *os.File {
+	t.Helper()
+
+	f, err := ioutil.TempFile("", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func deletefile(t *testing.T, f *os.File) {
+	t.Helper()
+	if err := os.Remove(f.Name()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readfile(t *testing.T, f *os.File) string {
+	t.Helper()
+	b, err := ioutil.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func reqString(t *testing.T, req *http.Request) string {
+	t.Helper()
+
+	h, err := hook.NewFromRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := h.Dump()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(s)
+}
+
+func TestRecord(t *testing.T) {
+	f := testfile(t, "hook.yml")
+	defer deletefile(t, f)
+
+	r, err := newRecorder(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.close()
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := `method: GET
+headers:
+  Accept-Encoding:
+  - gzip
+  User-Agent:
+  - Go-http-client/1.1
+body: ""
+`
+
+	client := http.DefaultClient
+
+	if _, err := client.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	got := readfile(t, f)
+	if d := diff.Diff(s, got); d != "" {
+		t.Error(d)
+	}
+
+	// Make request again to test appends.
+	if _, err := client.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf("%s---\n%s", s, s)
+	got = readfile(t, f)
+	if d := diff.Diff(want, got); d != "" {
+		t.Error(d)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eddiezane/hook
 go 1.13
 
 require (
+	github.com/kylelemons/godebug v1.1.0
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
Changes record to write multiple webhooks received in the same session
as separate documents separated by `---`.

Also refactors record to allow for testing of HTTP server bits.