### PR TITLE
Add multidoc fire support.

### DIFF
--- a/cmd/fire.go
+++ b/cmd/fire.go
@@ -25,13 +25,18 @@ func fire(cmd *cobra.Command, args []string) error {
 	}
 
 	path := args[0]
-	h, err := hook.NewFromPath(path)
+	hooks, err := hook.NewFromPath(path)
 	if err != nil {
 		return err
 	}
 
 	target := args[1]
-	res, err := h.Fire(target)
-	fmt.Println(res)
-	return err
+	for _, h := range hooks {
+		res, err := h.Fire(target)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eddiezane/hook
 go 1.13
 
 require (
+	github.com/google/go-cmp v0.3.1
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=


### PR DESCRIPTION
Allows yaml files specified to the fire command to send multiple
webhooks sequentially.

Also adds stricter testing for the pkg/hook tests.

Adds fire functionality for #5.