### PR TITLE
Add cache cloning and catalog update subcommand.

### DIFF
--- a/cmd/catalog_tap_test.go
+++ b/cmd/catalog_tap_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -59,14 +60,25 @@ func cachedir(t *testing.T) string {
 	return filepath.Join(d, "hook")
 }
 
-func TestAddConfig(t *testing.T) {
+// testdirInit creates a test directory, sets relevant environment variables,
+// and initializes hook configuration to read from the directory.
+func testdirInit(t *testing.T) string {
+	t.Helper()
 	d, err := ioutil.TempDir("", "hook")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(d)
 	os.Setenv("HOME", d)
+
+	viper.Reset()
 	initcfg()
+
+	return d
+}
+
+func TestAddConfig(t *testing.T) {
+	d := testdirInit(t)
+	defer os.RemoveAll(d)
 
 	if err := addConfig("https://example.com/foo", "", ""); err != nil {
 		t.Fatal(err)

--- a/cmd/catalog_update.go
+++ b/cmd/catalog_update.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	updateCmd = &cobra.Command{
+		Use:     "update <url>",
+		Short:   "Adds the given URL to the catalog config.",
+		Long:    "update updates a given catalog to the configured revision.",
+		Example: "hook catalog update <name>",
+		RunE:    update,
+	}
+
+	// newCommand wraps creating of commands to exec in order to allow
+	// mocking for testing.
+	newCommand func(name, command string, args ...string) runnable = execCommand
+)
+
+func init() {
+	catalogCmd.AddCommand(updateCmd)
+}
+
+type runnable interface {
+	Run() error
+}
+
+func execCommand(_, command string, args ...string) runnable {
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+func cloneRepo(name, url, dir, revision string) error {
+	args := []string{"clone"}
+	if revision != "" {
+		args = append(args, "-b", revision)
+	}
+	args = append(args, url, dir)
+
+	cmd := newCommand(name, "git", args...)
+	return cmd.Run()
+}
+
+func updateRepo(name, dir, revision string) error {
+	gitdir := filepath.Join(dir, ".git")
+	fetch := newCommand(name, "git",
+		"--git-dir", gitdir,
+		"--work-tree", dir,
+		"fetch", "origin", revision)
+	if err := fetch.Run(); err != nil {
+		return err
+	}
+
+	checkout := newCommand(name, "git",
+		"--git-dir", gitdir,
+		"--work-tree", dir,
+		"-c", "advice.detachedHead=false",
+		"checkout", "FETCH_HEAD")
+	return checkout.Run()
+}
+
+func updateConfig(names ...string) error {
+	rc, err := getRemoteConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(names) == 0 {
+		names = make([]string, 0, len(rc))
+		for k := range rc {
+			names = append(names, k)
+		}
+	}
+
+	for _, n := range names {
+		cfg, ok := rc[n]
+		if !ok {
+			log.Printf("config %s not found", n)
+			continue
+		}
+
+		log.Printf("updating %s@%s", cfg.Name, cfg.Revision)
+		dir := filepath.Join(viper.GetString("cache"), cfg.Name)
+
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err := cloneRepo(cfg.Name, cfg.URL, dir, cfg.Revision); err != nil {
+				return err
+			}
+		} else {
+			if err := updateRepo(cfg.Name, dir, cfg.Revision); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func update(cmd *cobra.Command, args []string) error {
+	initcfg()
+
+	return updateConfig(args...)
+}

--- a/cmd/catalog_update_test.go
+++ b/cmd/catalog_update_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// commandSink captures and stores commands created during execution.
+// It guarantees that the returned commands will be consistently ordered by repo
+// and by command order.
+// It does not guarantee that the repo ordering will be identical to the config
+// ordering.
+type commandSink struct {
+	cmd []*mockCommand
+}
+
+func (c *commandSink) reset() {
+	c.cmd = []*mockCommand{}
+}
+
+// sort ensure consistent return order for comparisons by sorting by
+// (catalog name, order event occured).
+func (c *commandSink) sort() {
+	sort.Slice(c.cmd, func(i, j int) bool {
+		iName := c.cmd[i].name
+		jName := c.cmd[j].name
+		// Sort by catalog name first, then by command ordering.
+		if iName != jName {
+			return strings.Compare(iName, jName) < 0
+		}
+		return c.cmd[i].idx < c.cmd[j].idx
+	})
+}
+
+func (c *commandSink) commands() [][]string {
+	c.sort()
+	out := make([][]string, 0, len(c.cmd))
+	for _, v := range c.cmd {
+		out = append(out, v.args)
+	}
+	return out
+}
+
+func (c *commandSink) record(name, command string, args ...string) runnable {
+	cmd := &mockCommand{
+		name: name,
+		idx:  len(args),
+		args: append([]string{command}, args...),
+	}
+	c.cmd = append(c.cmd, cmd)
+	return cmd
+}
+
+// mockCommand simulates a exec-ed command without invoking an external shell
+// or the network. If mockCommand recognizes the request as a clone, it will
+// create the specified directory to simulate a clone of the repo.
+type mockCommand struct {
+	// Catalog name command is acting on behalf of.
+	// Used to guarantee consistent command return order.
+	name string
+	// Overall command index number. This is not necessarily tied to the specific
+	// catalog name, but gives overall ordering of the commands.
+	idx int
+	// Command arguments that were called.
+	args []string
+}
+
+func (c mockCommand) Run() error {
+	if c.args[1] == "clone" {
+		dir := c.args[3]
+		return os.MkdirAll(dir, 0700)
+	}
+	return nil
+}
+
+func (c mockCommand) String() string {
+	return strings.Join(c.args, " ")
+}
+
+func TestCatalogUpdate(t *testing.T) {
+	d := testdirInit(t)
+	defer os.RemoveAll(d)
+
+	c := &commandSink{}
+	newCommand = c.record
+
+	if err := updateConfig(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := addConfig("https://example.com/foo", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateConfig(); err != nil {
+		t.Fatal(err)
+	}
+	want := [][]string{{"git", "clone", "https://example.com/foo", filepath.Join(cachedir(t), "foo")}}
+	if diff := cmp.Diff(want, c.commands()); diff != "" {
+		t.Error(diff)
+	}
+
+	c.reset()
+
+	if err := addConfig("https://example.com/bar", "tacocat", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateConfig(); err != nil {
+		t.Fatal(err)
+	}
+	want = [][]string{
+		{
+			"git",
+			"--git-dir", filepath.Join(cachedir(t), "foo", ".git"),
+			"--work-tree", filepath.Join(cachedir(t), "foo"),
+			"fetch", "origin", "",
+		},
+		{
+			"git",
+			"--git-dir", filepath.Join(cachedir(t), "foo", ".git"),
+			"--work-tree", filepath.Join(cachedir(t), "foo"),
+			"-c", "advice.detachedHead=false",
+			"checkout", "FETCH_HEAD",
+		},
+		{"git", "clone", "-b", "v1", "https://example.com/bar", filepath.Join(cachedir(t), "tacocat")},
+	}
+	if diff := cmp.Diff(want, c.commands()); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
This enables cloning repositories into the local cache based on the
given configuration.

This intentionally relies on execing out to the git client on the users
path (instead of using a library such as go-git) in order to rely on
existing git configuration and credential helpers for authentication and
other settings.

Most of the complexity in this CL comes from the need to mock out exec
calls.

There's some opportunity here to make passing catalog information
cleaner by tying the git funcs to the remote configs themselves, but
unclear if this is something worth doing yet.

Adds repo cloning for #4.

Dependent on #11 (do not submit until that has been reviewed and submitted).