### PR TITLE
Pretty print HTTP payload body.

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -56,7 +56,9 @@ func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	s, err := h.Dump()
 	if err != nil {
-		log.Fatal(err)
+		log.Println("error dumping hook:", err, h)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 	// TODO(eddiezane): Would this ever happen?
 	if len(s) != 0 {
@@ -67,11 +69,15 @@ func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if fi, err := r.f.Stat(); err == nil && fi.Size() > 0 {
 			// If file has data in it already, append doc separator.
 			if _, err := fw.Write([]byte("---\n")); err != nil {
-				log.Fatal(err)
+				log.Println("error writing doc separator:", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
 			}
 		}
 		if _, err := fw.Write(s); err != nil {
-			log.Fatal(err)
+			log.Println("error writing file:", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 		fw.Flush()
 	}


### PR DESCRIPTION
The yaml library will wrap lines at spaces after certain lengths, which
breaks large hook payloads. This marshals the body into JSON which also
has the benefit of switching to block format for payload bodies.

https://gist.github.com/wlynch/29e8d2818b4e8d77149e750b4c3590eb