### PR TITLE
Fix pretty-print header test, base64 encoding for structs.

### DIFF
--- a/cmd/record_test.go
+++ b/cmd/record_test.go
@@ -107,9 +107,11 @@ params:
 			want: `method: POST
 headers:
   Accept-Encoding:
-  - application/json
+  - gzip
   Content-Length:
   - "14"
+  Content-Type:
+  - application/json
   User-Agent:
   - Go-http-client/1.1
 body: |-
@@ -118,17 +120,19 @@ body: |-
   }
 `,
 			method:  http.MethodPost,
-			headers: http.Header{"Accept-Encoding": []string{"application/json"}},
+			headers: http.Header{"Content-Type": []string{"application/json"}},
 			body:    `{"foo": "bar"}`,
 		},
 		{
-			name: "base64 decode",
+			name: "base64 decode field",
 			want: `method: POST
 headers:
   Accept-Encoding:
-  - application/json
+  - gzip
   Content-Length:
   - "15"
+  Content-Type:
+  - application/json
   User-Agent:
   - Go-http-client/1.1
 body: |-
@@ -140,8 +144,35 @@ transform:
   - foo
 `,
 			method:  http.MethodPost,
-			headers: http.Header{"Accept-Encoding": []string{"application/json"}},
+			headers: http.Header{"Content-Type": []string{"application/json"}},
 			body:    `{"foo": "YmFy"}`,
+			opts:    []hook.Option{hook.DecodeOption(hook.Base64Transformer{}, "foo")},
+		},
+		{
+			name: "base64 decode struct",
+			want: `method: POST
+headers:
+  Accept-Encoding:
+  - gzip
+  Content-Length:
+  - "31"
+  Content-Type:
+  - application/json
+  User-Agent:
+  - Go-http-client/1.1
+body: |-
+  {
+    "foo": {
+      "bar": "baz"
+    }
+  }
+transform:
+  base64:
+  - foo
+`,
+			method:  http.MethodPost,
+			headers: http.Header{"Content-Type": []string{"application/json"}},
+			body:    `{"foo": "eyJiYXIiOiAiYmF6In0="}`,
 			opts:    []hook.Option{hook.DecodeOption(hook.Base64Transformer{}, "foo")},
 		},
 	}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -118,7 +118,7 @@ func New(r io.Reader) ([]*Hook, error) {
 
 // Dump TODO(eddiezane): Is this the right method?
 func (h *Hook) Dump() ([]byte, error) {
-	switch h.Headers.Get("Accept-Encoding") {
+	switch h.Headers.Get("Content-Type") {
 	case "application/json":
 		return yaml.Marshal(&jsonMarshal{
 			Method:    h.Method,

--- a/pkg/hook/transform.go
+++ b/pkg/hook/transform.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"encoding/base64"
+	"encoding/json"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -46,13 +47,18 @@ func (Base64Transformer) Encode(json string, path string) (string, error) {
 }
 
 // Decode takes the given payload + path and base64 decodes the value.
-func (Base64Transformer) Decode(json string, path string) (string, error) {
-	in := gjson.Get(json, path).String()
+func (Base64Transformer) Decode(raw string, path string) (string, error) {
+	in := gjson.Get(raw, path).String()
 	out, err := base64.StdEncoding.DecodeString(in)
 	if err != nil {
 		return "", err
 	}
-	return sjson.Set(json, path, out)
+
+	var js map[string]interface{}
+	if json.Unmarshal(out, &js) == nil {
+		return sjson.SetRaw(raw, path, string(out))
+	}
+	return sjson.Set(raw, path, out)
 }
 
 type decodeOption struct {


### PR DESCRIPTION
Pretty printing should use the Content-Type header, not Accept-Encoding
for determining whether the payload contains json or not.

For base64 encoding, the field may be either a primitive value,
(e.g. "a", 1) or a nested JSON struct. We want to handle these
differently to make sure that sjson doesn't string escape nested json,
so test that the decoded type is a valid JSON object and if so, set the
value directly with no escaping.